### PR TITLE
Several fixes around save

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -25,6 +25,7 @@ func (a *AccountData) issue(key *Key) error {
 	}
 	a.Claim = claim
 	a.Token = token
+	a.Modified = true
 	return nil
 }
 

--- a/operator.go
+++ b/operator.go
@@ -148,6 +148,7 @@ func (o *OperatorData) update() error {
 	}
 	o.Claim = claims
 	o.Token = token
+	o.Modified = true
 
 	return nil
 }

--- a/operator_signingkeys.go
+++ b/operator_signingkeys.go
@@ -19,13 +19,13 @@ func (os *operatorSigningKeys) add() (*Key, error) {
 	if err != nil {
 		return nil, err
 	}
+	os.data.Claim.SigningKeys.Add(key.Public)
 	err = os.data.update()
 	if err != nil {
 		return nil, err
 	}
 	os.data.AddedKeys = append(os.data.AddedKeys, key)
 	os.data.OperatorSigningKeys = append(os.data.OperatorSigningKeys, key)
-	os.data.Claim.SigningKeys = append(os.data.Claim.SigningKeys, key.Public)
 	return key, nil
 }
 

--- a/providers/kv/kv.go
+++ b/providers/kv/kv.go
@@ -225,6 +225,7 @@ func (p *KvProvider) LoadOperators() ([]*ab.OperatorData, error) {
 			return nil, err
 		}
 		o.Claim = oc
+		o.Modified = false
 		o.Loaded = o.Claim.IssuedAt
 		o.EntityName = o.Claim.Name
 		o.Key, err = p.GetKey(o.Claim.Subject)
@@ -260,6 +261,7 @@ func (p *KvProvider) LoadAccounts(od *ab.OperatorData) error {
 		if err != nil {
 			return err
 		}
+		a.Modified = false
 		a.Claim = ac
 		a.Loaded = a.Claim.IssuedAt
 		a.EntityName = a.Claim.Name
@@ -297,6 +299,7 @@ func (p *KvProvider) LoadUsers(ad *ab.AccountData) error {
 			return err
 		}
 		u.Claim = uc
+		u.Modified = false
 		u.Loaded = u.Claim.IssuedAt
 		u.EntityName = u.Claim.Name
 		u.Key, err = p.GetKey(u.Claim.Subject)
@@ -400,7 +403,7 @@ func (p *KvProvider) Store(operators []*ab.OperatorData) error {
 }
 
 func (p *KvProvider) StoreOperator(o *ab.OperatorData) error {
-	if o.Loaded > 0 && o.Loaded > o.Claim.IssuedAt {
+	if !o.Modified {
 		return nil
 	}
 	_, err := p.Kv.Put(context.Background(), fmt.Sprintf("%s.%s", OperatorPrefix, o.Subject()), []byte(o.Token))
@@ -416,11 +419,12 @@ func (p *KvProvider) StoreOperator(o *ab.OperatorData) error {
 		}
 	}
 	o.Loaded = o.Claim.IssuedAt
+	o.Modified = false
 	return nil
 }
 
 func (p *KvProvider) StoreAccount(a *ab.AccountData) error {
-	if a.Loaded > 0 && a.Loaded > a.Claim.IssuedAt {
+	if !a.Modified {
 		return nil
 	}
 	_, err := p.Kv.Put(context.Background(),
@@ -438,11 +442,12 @@ func (p *KvProvider) StoreAccount(a *ab.AccountData) error {
 		}
 	}
 	a.Loaded = a.Claim.IssuedAt
+	a.Modified = false
 	return nil
 }
 
 func (p *KvProvider) StoreUser(u *ab.UserData) error {
-	if u.Loaded > 0 && u.Loaded > u.Claim.IssuedAt {
+	if !u.Modified {
 		return nil
 	}
 	_, err := p.Kv.Put(context.Background(),
@@ -452,6 +457,7 @@ func (p *KvProvider) StoreUser(u *ab.UserData) error {
 		return err
 	}
 	u.Loaded = u.Claim.IssuedAt
+	u.Modified = false
 	return nil
 }
 

--- a/tests/accounts_test.go
+++ b/tests/accounts_test.go
@@ -551,3 +551,44 @@ func (suite *ProviderSuite) Test_AccountJetStreamLimits() {
 	require.NoError(t, err)
 	suite.testTier(auth, b, 1)
 }
+
+func (suite *ProviderSuite) Test_AccountSkUpdate() {
+	t := suite.T()
+	auth, err := authb.NewAuth(suite.Provider)
+	require.NoError(t, err)
+
+	operators := auth.Operators()
+	require.Empty(t, operators.List())
+
+	o, err := operators.Add("O")
+	require.NoError(t, err)
+	require.NotNil(t, o)
+
+	a, err := o.Accounts().Add("A")
+	require.NoError(t, err)
+	require.NotNil(t, a)
+
+	require.NoError(t, auth.Commit())
+	require.NoError(t, auth.Reload())
+
+	o = operators.Get("O")
+	require.NotNil(t, o)
+
+	a = o.Accounts().Get("A")
+	require.NotNil(t, a)
+
+	k, err := a.ScopedSigningKeys().Add()
+	require.NoError(t, err)
+	require.NotEmpty(t, k)
+
+	require.NoError(t, auth.Commit())
+	require.NoError(t, auth.Reload())
+
+	o = operators.Get("O")
+	require.NotNil(t, o)
+	a = o.Accounts().Get("A")
+	require.NotNil(t, a)
+	scope, ok := a.ScopedSigningKeys().GetScope(k)
+	require.Nil(t, scope)
+	require.True(t, ok)
+}

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -39,6 +39,41 @@ func (suite *ProviderSuite) Test_OperatorBasics() {
 	require.Equal(t, oc.Subject, key.Public)
 }
 
+func (suite *ProviderSuite) Test_SkUpdate() {
+	t := suite.T()
+	auth, err := authb.NewAuth(suite.Provider)
+	require.NoError(t, err)
+
+	operators := auth.Operators()
+	require.Empty(t, operators.List())
+
+	o := auth.Operators().Get("O")
+	require.NoError(t, err)
+	require.Nil(t, o)
+	o, err = operators.Add("O")
+	require.NoError(t, err)
+	require.NotNil(t, o)
+
+	require.NoError(t, auth.Commit())
+	require.NoError(t, auth.Reload())
+
+	o = operators.Get("O")
+	require.NotNil(t, o)
+
+	k, err := o.SigningKeys().Add()
+	require.NoError(t, err)
+	require.NotEmpty(t, k)
+
+	require.NoError(t, auth.Commit())
+	require.NoError(t, auth.Reload())
+
+	o = operators.Get("O")
+	require.NotNil(t, o)
+	keys := o.SigningKeys().List()
+	require.Len(t, keys, 1)
+	require.Contains(t, keys, k)
+}
+
 func (suite *ProviderSuite) Test_OperatorValidation() {
 	t := suite.T()
 	auth, err := authb.NewAuth(suite.Provider)

--- a/tests/users_test.go
+++ b/tests/users_test.go
@@ -337,3 +337,37 @@ func (suite *ProviderSuite) Test_Creds() {
 	ud := u.(*authb.UserData)
 	require.Equal(t, int64(0), ud.Claim.Expires)
 }
+
+func (suite *ProviderSuite) Test_UsersAddedSave() {
+	t := suite.T()
+	auth, err := authb.NewAuth(suite.Provider)
+	require.NoError(t, err)
+	o, err := auth.Operators().Add("O")
+	require.NoError(t, err)
+	require.NotNil(t, o)
+	a, err := o.Accounts().Add("A")
+	require.NoError(t, err)
+	require.NotNil(t, a)
+
+	require.NoError(t, auth.Commit())
+	require.NoError(t, auth.Reload())
+
+	o = auth.Operators().Get("O")
+	require.NotNil(t, o)
+	a = o.Accounts().Get("A")
+	require.NotNil(t, a)
+
+	u, err := a.Users().Add("U", "")
+	require.NoError(t, err)
+	require.NotNil(t, u)
+
+	require.NoError(t, auth.Commit())
+	require.NoError(t, auth.Reload())
+
+	o = auth.Operators().Get("O")
+	require.NotNil(t, o)
+	a = o.Accounts().Get("A")
+	require.NotNil(t, a)
+	u = a.Users().Get("U")
+	require.NotNil(t, u)
+}

--- a/types.go
+++ b/types.go
@@ -30,9 +30,11 @@ type BaseData struct {
 	// Loaded matches the issue time of a loaded JWT (UTC in seconds). When
 	// the entity is new, it should be 0. The AuthProvider
 	// stores claims that have been modified and have
-	// an issue time greater than this value. On Store(),
+	// an issue time greater than this value or have been Modified. On Store(),
 	// it should be set to the tokens issue time.
 	Loaded int64
+	// Modified is true if the entity has been modified since it was loaded
+	Modified bool
 	// EntityName is the name for the entity - in some cases NSC
 	// will display simple name which differs from the actual name
 	// of the entity stored in the JWT.

--- a/user.go
+++ b/user.go
@@ -48,6 +48,8 @@ func (u *UserData) update() error {
 	}
 	u.Claim = claim
 	u.Token = token
+	u.Loaded = claim.IssuedAt
+	u.Modified = true
 	return nil
 }
 

--- a/users.go
+++ b/users.go
@@ -23,7 +23,7 @@ func (a *UsersImpl) Add(name string, key string) (User, error) {
 		return nil, err
 	}
 	d := &UserData{
-		BaseData:    BaseData{EntityName: name, Key: uk},
+		BaseData:    BaseData{EntityName: name, Key: uk, Modified: true},
 		AccountData: a.accountData,
 		Claim:       jwt.NewUserClaims(uk.Public),
 		RejectEdits: scoped,


### PR DESCRIPTION
- [FIX] update when adding operator key, updated before adding the signing key to the jwt (FIX #15)
- [FIX] changed save logic depended which depended on `Loaded` field which only has second resolution to be based out of `Modified` 
- [FIX] nscprovider expected an account key to have an operator prefix instead of an account prefix 
- [FIX] nscprovider saving of users depended on the account being modified