### PR TITLE
Ensure the operator token is set during load

### DIFF
--- a/providers/nsc/nsc.go
+++ b/providers/nsc/nsc.go
@@ -83,7 +83,7 @@ func (a *NscProvider) loadOperator(si store.IStore) (*authb.OperatorData, error)
 	if err != nil {
 		return nil, err
 	}
-	od := &authb.OperatorData{BaseData: authb.BaseData{EntityName: si.GetName(), Loaded: oc.IssuedAt}, Claim: oc}
+	od := &authb.OperatorData{BaseData: authb.BaseData{EntityName: si.GetName(), Loaded: oc.IssuedAt, Token: string(token)}, Claim: oc}
 	ks := store.NewKeyStore(od.EntityName)
 	kp, err := ks.GetKeyPair(oc.Issuer)
 	if err != nil {

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -212,6 +212,25 @@ func (suite *ProviderSuite) Test_OperatorSystemAccount() {
 	require.NoError(t, o.Accounts().Delete("SYS"))
 }
 
+func (suite *ProviderSuite) Test_MemResolver() {
+	t := suite.T()
+	auth, err := authb.NewAuth(suite.Provider)
+	require.NoError(t, err)
+
+	_, err = auth.Operators().Add("O")
+	require.NoError(t, err)
+
+	require.NoError(t, auth.Commit())
+
+	auth, err = authb.NewAuth(suite.Provider)
+	require.NoError(t, err)
+
+	o := auth.Operators().Get("O")
+
+	_, err = o.MemResolver()
+	require.NoError(t, err)
+}
+
 func (suite *ProviderSuite) Test_OperatorImport() {
 	t := suite.T()
 	auth, err := authb.NewAuth(suite.Provider)


### PR DESCRIPTION
Avoids: `expected 3 chunks` error from `MemResolver()`