### PR TITLE
Handle go casting right

### DIFF
--- a/service_exports.go
+++ b/service_exports.go
@@ -11,7 +11,12 @@ type serviceExports struct {
 }
 
 func (s *serviceExports) Get(subject string) ServiceExport {
-	return s.getServiceExport(subject)
+	se := s.getServiceExport(subject)
+	if se == nil {
+		return nil
+	}
+
+	return se
 }
 
 func (s *serviceExports) GetByName(name string) ServiceExport {


### PR DESCRIPTION
Because we're returning from an embedded type go
will never consider this result as nil from
the caller.

Handle it here and return actual nil