### PR TITLE
Allow custom subjects for activations

### DIFF
--- a/exports.go
+++ b/exports.go
@@ -201,7 +201,7 @@ func (b *baseExportImpl) SetAdvertised(tf bool) error {
 	return b.update()
 }
 
-func (b *baseExportImpl) GenerateActivation(account string, issuer string) (string, error) {
+func (b *baseExportImpl) GenerateActivation(subject string, account string, issuer string) (string, error) {
 	if !b.TokenRequired() {
 		return "", fmt.Errorf("export is public and doesn't require an activation")
 	}
@@ -210,7 +210,13 @@ func (b *baseExportImpl) GenerateActivation(account string, issuer string) (stri
 		return "", err
 	}
 	ac := jwt.NewActivationClaims(key.Public)
-	ac.ImportSubject = b.export.Subject
+
+	if subject == "" {
+		ac.ImportSubject = b.export.Subject
+	} else {
+		ac.ImportSubject = jwt.Subject(subject)
+	}
+
 	ac.ImportType = b.export.Type
 
 	k, signingKey, err := b.data.getKey(issuer)

--- a/tests/imports_test.go
+++ b/tests/imports_test.go
@@ -340,7 +340,7 @@ func (t *ProviderSuite) Test_NewStreamImportToken() {
 	t.NoError(err)
 	t.NotNil(si)
 
-	token, err := export.GenerateActivation(a.Subject(), b.Subject())
+	token, err := export.GenerateActivation("s.123", a.Subject(), b.Subject())
 	t.NoError(err)
 	t.NotEmpty(token)
 	t.NoError(si.SetToken(token))
@@ -365,7 +365,7 @@ func (t *ProviderSuite) Test_NewStreamImportSkToken() {
 	t.NoError(err)
 	t.NotNil(si)
 
-	token, err := export.GenerateActivation(a.Subject(), sk)
+	token, err := export.GenerateActivation("", a.Subject(), sk)
 	t.NoError(err)
 	t.NotEmpty(token)
 	t.NoError(si.SetToken(token))
@@ -410,7 +410,7 @@ func (t *ProviderSuite) Test_NewServiceImportToken() {
 	t.NoError(err)
 	t.NotNil(si)
 
-	token, err := export.GenerateActivation(a.Subject(), b.Subject())
+	token, err := export.GenerateActivation("", a.Subject(), b.Subject())
 	t.NoError(err)
 	t.NotEmpty(token)
 	t.NoError(si.SetToken(token))
@@ -435,7 +435,7 @@ func (t *ProviderSuite) Test_NewServiceImportSkToken() {
 	t.NoError(err)
 	t.NotNil(si)
 
-	token, err := export.GenerateActivation(a.Subject(), sk)
+	token, err := export.GenerateActivation("", a.Subject(), sk)
 	t.NoError(err)
 	t.NotEmpty(token)
 	t.NoError(si.SetToken(token))

--- a/types.go
+++ b/types.go
@@ -591,7 +591,7 @@ type Export interface {
 	// the notion of Advertised may not be implemented by the operator
 	SetAdvertised(tf bool) error
 	// GenerateActivation an activation token for the specified account signed with the specified issuer
-	GenerateActivation(account string, issuer string) (string, error)
+	GenerateActivation(subject string, account string, issuer string) (string, error)
 }
 
 type SamplingRate int


### PR DESCRIPTION
nsc allows for activation tokens for export private.* to be generated with private.123 which allows for per account subjects

To allow the same we need to accept a subject when generating an activation