### PR TITLE
SetUserPermissionLimits() didn't have an effect

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -21,8 +21,12 @@ func (u *UserPermissions) SetUserPermissionLimits(limits jwt.UserPermissionLimit
 	if u.rejectEdits {
 		return ErrUserIsScoped
 	}
-
 	u.limits = &limits
+	if u.scope != nil {
+		u.scope.Template = limits
+	} else {
+		u.userData.Claim.UserPermissionLimits = limits
+	}
 	return u.update()
 }
 


### PR DESCRIPTION
[FIX] SetUserPermissionLimits was only setting the edited limits and didn't update the actual target (user or scope), so setting jwt.UserPermissionLimits didn't have an effect.

Fix #44 