### PR TITLE
Add support for importing ephemeral users from claims

### DIFF
--- a/tests/accounts_test.go
+++ b/tests/accounts_test.go
@@ -2,8 +2,9 @@ package tests
 
 import (
 	"fmt"
-	"github.com/nats-io/nkeys"
 	"time"
+
+	"github.com/nats-io/nkeys"
 
 	"github.com/nats-io/jwt/v2"
 	authb "github.com/synadia-io/jwt-auth-builder.go"

--- a/tests/external_test.go
+++ b/tests/external_test.go
@@ -2,11 +2,12 @@ package tests
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/nats-io/nkeys"
 	"github.com/stretchr/testify/assert"
 	authb "github.com/synadia-io/jwt-auth-builder.go"
 	nsc "github.com/synadia-io/jwt-auth-builder.go/providers/nsc"
-	"testing"
 )
 
 func TestExternal(v *testing.T) {

--- a/tests/users_test.go
+++ b/tests/users_test.go
@@ -1,8 +1,9 @@
 package tests
 
 import (
-	"github.com/nats-io/nkeys"
 	"time"
+
+	"github.com/nats-io/nkeys"
 
 	"github.com/nats-io/jwt/v2"
 	authb "github.com/synadia-io/jwt-auth-builder.go"

--- a/types.go
+++ b/types.go
@@ -348,6 +348,8 @@ type Users interface {
 	// If the provided ID is only a public key the user will be ephemeral and will not stored,
 	// other operations, as cred generation will fail
 	AddWithIdentity(name string, signer string, id string) (User, error)
+	// ImportEphemeral imports an ephemeral user from a claim
+	ImportEphemeral(c *jwt.UserClaims, key string) (User, error)
 	// Delete the user by matching its name or subject
 	Delete(name string) error
 	// Get returns the user by matching its name or subject


### PR DESCRIPTION
Implemented the `ImportEphemeral` for handling ephemeral users with claims. Updated interfaces and tests to reflect this new functionality. Fixed minor import ordering issues in test files for consistency.