### PR TITLE
Update key generation to use signing service API

### DIFF
--- a/account_signingkeys.go
+++ b/account_signingkeys.go
@@ -16,7 +16,7 @@ func (as *accountSigningKeys) List() []string {
 }
 
 func (as *accountSigningKeys) Add() (string, error) {
-	k, err := KeyFor(nkeys.PrefixByteAccount)
+	k, err := as.data.Operator.SigningService.NewKey(nkeys.PrefixByteAccount)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Replaced direct key generation with the signing service's `NewKey` method for better integration and consistency. Adjusted the `Add` method to utilize this updated approach. This ensures alignment with the operator's signing process.