### PR TITLE
Add `IssueClaim` method for operators and accounts

### DIFF
--- a/types.go
+++ b/types.go
@@ -263,6 +263,8 @@ type Operator interface {
 	JWT() string
 	// Tags returns an object that you can use to manage tags for the operator
 	Tags() Tags
+	// IssueClaim issues the specified jwt.Claim using the specified operator key
+	IssueClaim(claim jwt.Claims, key string) (string, error)
 }
 
 // Accounts is an interface for managing accounts
@@ -332,7 +334,10 @@ type Account interface {
 	// if the users value is nil, ExternalAuthorization is not enabled
 	ExternalAuthorization() ([]string, []string, string)
 
+	// IssueAuthorizationResponse generates a signed JWT token for an AuthorizationResponseClaims using the specified key.
 	IssueAuthorizationResponse(claim *jwt.AuthorizationResponseClaims, key string) (string, error)
+	// IssueClaim issues the specified jwt.Claim using the specified account key
+	IssueClaim(claim jwt.Claims, key string) (string, error)
 }
 
 // Users is an interface for managing users


### PR DESCRIPTION
Introduce the `IssueClaim` method to streamline JWT claim issuance for operators and accounts. This includes validation for claim types and appropriate restrictions for operator and scoped account signing keys.