### PR TITLE
Fix key comparison logic in operator sign api

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -168,7 +168,7 @@ func (o *OperatorData) IssueClaim(claim jwt.Claims, key string) (string, error) 
 	}
 
 	var k *Key
-	if key == "" {
+	if key == "" || key == o.Key.Public {
 		k = o.Key
 	} else {
 		for _, sk := range o.OperatorSigningKeys {


### PR DESCRIPTION
Update the logic to handle cases where the key is empty or matches the operator's public key. This ensures proper assignment to the default operator key, improving stability and preventing potential misconfiguration issues.