### PR TITLE
Add subject mappings support for accounts

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -78,11 +78,11 @@ type OperatorsImpl struct {
 }
 
 func (a *AuthImpl) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&struct {
+	return json.MarshalIndent(&struct {
 		Operators []*OperatorData `json:"operators"`
 	}{
 		Operators: a.operators,
-	})
+	}, "", "  ")
 }
 
 func (a *AuthImpl) UnmarshalJSON(data []byte) error {

--- a/tests/accounts_test.go
+++ b/tests/accounts_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/nats-io/nkeys"
 
 	"github.com/nats-io/jwt/v2"
@@ -922,7 +924,7 @@ func (t *ProviderSuite) Test_ExternalAuthorization() {
 	t.Empty(accounts)
 	t.Empty(key)
 
-	t.NoError(external.SetExternalAuthorizationUser([]authb.User{u}, []authb.Account{a}, curve.Public))
+	t.NoError(external.SetExternalAuthorizationUser([]interface{}{u}, []interface{}{a}, curve.Public))
 
 	t.NoError(auth.Commit())
 	t.NoError(auth.Reload())
@@ -1028,4 +1030,43 @@ func (t *ProviderSuite) Test_AccountSignClaim() {
 	_, err = a.IssueClaim(ac, scope.Key())
 	t.Error(err)
 	t.Contains(err.Error(), "accounts can only self-sign")
+}
+
+func (t *ProviderSuite) Test_SubjectMapping() {
+	auth, err := authb.NewAuth(t.Provider)
+	t.NoError(err)
+	o, err := auth.Operators().Add("O")
+	t.NoError(err)
+	a, err := o.Accounts().Add("A")
+	t.NoError(err)
+
+	sm := a.SubjectMappings()
+	t.Empty(sm.List())
+
+	err = sm.Set("foo", authb.Mapping{
+		Subject: "bar",
+		Weight:  10,
+	}, authb.Mapping{
+		Subject: "baz",
+		Weight:  20,
+	})
+	require.NoError(t.T(), err)
+	mappings := sm.List()
+	t.Len(mappings, 1)
+	t.Contains(mappings, "foo")
+
+	entries := sm.Get("foo")
+	t.Len(entries, 2)
+	t.Equal(entries[0].Subject, "bar")
+	t.Equal(entries[1].Subject, "baz")
+
+	err = sm.Set("bar", authb.Mapping{
+		Subject: "baz",
+		Weight:  110,
+	})
+	t.Error(err)
+	t.Nil(sm.Get("bar"))
+
+	t.NoError(sm.Delete("foo"))
+	t.NoError(sm.Delete("foo"))
 }

--- a/types.go
+++ b/types.go
@@ -328,7 +328,9 @@ type Account interface {
 
 	// SetExternalAuthorizationUser updates external authorization by associating users public keys, account public keys, and an encryption key.
 	// ExternalAuthorization requires at the very list one user
-	SetExternalAuthorizationUser(users []User, accounts []Account, encryption string) error
+	// users can pass reference to User or the public key of the user
+	// accounts can pass references to Account or the public key of the account
+	SetExternalAuthorizationUser(users []interface{}, accounts []interface{}, encryption string) error
 
 	// ExternalAuthorization retrieves a list of authorized users, associated accounts, and encryption key.
 	// if the users value is nil, ExternalAuthorization is not enabled
@@ -338,6 +340,29 @@ type Account interface {
 	IssueAuthorizationResponse(claim *jwt.AuthorizationResponseClaims, key string) (string, error)
 	// IssueClaim issues the specified jwt.Claim using the specified account key
 	IssueClaim(claim jwt.Claims, key string) (string, error)
+
+	SubjectMappings() SubjectMappings
+}
+
+type SubjectMappings interface {
+	Get(subject string) Mappings
+	Set(subject string, m ...Mapping) error
+	Delete(subject string) error
+	List() []string
+}
+
+type Mappings = []Mapping
+
+type Mapping struct {
+	// Destination subject
+	Subject string
+	// Weight of the mapping from 0 to 100 (representing 100%)
+	// Note that the sum of all the mappings must not have a weight greater than 100
+	// If Cluster is specified, the total of each cluster grouping must not exceed 100
+	Weight uint8
+	// Optional cluster name, if specified the weight for the cluster is independent
+	// of the other Cluster or non-clustered mappings
+	Cluster string
 }
 
 // Users is an interface for managing users


### PR DESCRIPTION
Introduced a SubjectMappings interface and corresponding implementation for managing subject mappings in accounts. Includes methods to get, set, delete, and list mappings, with associated validation rules. Added tests to verify functionality, ensuring correct behavior and error handling.

Fix #62 