### PR TITLE
Add SetIssuer method for account operator key selection

### DIFF
--- a/tests/accounts_test.go
+++ b/tests/accounts_test.go
@@ -1103,4 +1103,7 @@ func (t *ProviderSuite) Test_AccountIssuer() {
 	t.NotEmpty(sk)
 	t.NoError(a.SetIssuer(sk))
 	t.Equal(a.Issuer(), sk)
+
+	t.NoError(a.SetIssuer(""))
+	t.Equal(a.Issuer(), o.Subject())
 }

--- a/tests/accounts_test.go
+++ b/tests/accounts_test.go
@@ -1089,11 +1089,13 @@ func (t *ProviderSuite) Test_AccountIssuer() {
 	t.Equal(a.Issuer(), o.Subject())
 
 	bad, err := authb.KeyFor(nkeys.PrefixByteAccount)
+	t.NoError(err)
 	err = a.SetIssuer(bad.Public)
 	t.Error(err)
 	t.Equal(err.Error(), "nkeys: incompatible key")
 
 	unknown, err := authb.KeyFor(nkeys.PrefixByteOperator)
+	t.NoError(err)
 	err = a.SetIssuer(unknown.Public)
 	t.Error(err)
 	t.Equal(err.Error(), "issuer is not a registered operator key")

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -184,23 +184,6 @@ func (t *ProviderSuite) Test_OperatorUsesMainKeyToSignAccount() {
 	t.NoError(auth.Commit())
 }
 
-func (t *ProviderSuite) Test_OperatorUsesSigningKeyToSignAccount() {
-	auth, err := authb.NewAuth(t.Provider)
-	t.NoError(err)
-	o, err := auth.Operators().Add("O")
-	t.NoError(err)
-	sk, err := o.SigningKeys().Add()
-	t.NoError(err)
-	t.NotEmpty(sk)
-	a, err := o.Accounts().Add("A")
-	t.NoError(err)
-	t.NotNil(sk, a.Issuer())
-	t.NoError(auth.Commit())
-
-	ac := t.Store.GetAccount("O", "A")
-	t.Equal(sk, ac.ClaimsData.Issuer)
-}
-
 func (t *ProviderSuite) Test_OperatorRotate() {
 	auth, err := authb.NewAuth(t.Provider)
 	t.NoError(err)
@@ -211,6 +194,9 @@ func (t *ProviderSuite) Test_OperatorRotate() {
 	t.NotEmpty(sk)
 	a, err := o.Accounts().Add("A")
 	t.NoError(err)
+	t.Equal(o.Subject(), a.Issuer())
+
+	t.NoError(a.SetIssuer(sk))
 	t.Equal(sk, a.Issuer())
 	t.NoError(auth.Commit())
 

--- a/types.go
+++ b/types.go
@@ -312,6 +312,9 @@ type Account interface {
 	// SetExpiry sets the expiry for the account in Unix Time Seconds.
 	// 0 never expires.
 	SetExpiry(exp int64) error
+	// SetIssuer sets the operator key to use (default is operator). If
+	// set to empty string, it will use the operator identity key
+	SetIssuer(issuer string) error
 	// Expiry returns the expiry for the account in Unix Time Seconds.
 	// 0 never expires
 	Expiry() int64
@@ -340,6 +343,29 @@ type Account interface {
 	IssueAuthorizationResponse(claim *jwt.AuthorizationResponseClaims, key string) (string, error)
 	// IssueClaim issues the specified jwt.Claim using the specified account key
 	IssueClaim(claim jwt.Claims, key string) (string, error)
+
+	SubjectMappings() SubjectMappings
+}
+
+type SubjectMappings interface {
+	Get(subject string) Mappings
+	Set(subject string, m ...Mapping) error
+	Delete(subject string) error
+	List() []string
+}
+
+type Mappings = []Mapping
+
+type Mapping struct {
+	// Destination subject
+	Subject string
+	// Weight of the mapping from 0 to 100 (representing 100%)
+	// Note that the sum of all the mappings must not have a weight greater than 100
+	// If Cluster is specified, the total of each cluster grouping must not exceed 100
+	Weight uint8
+	// Optional cluster name, if specified the weight for the cluster is independent
+	// of the other Cluster or non-clustered mappings
+	Cluster string
 }
 
 // Users is an interface for managing users


### PR DESCRIPTION
Introduces the `SetIssuer()` method on the account which allow specifying which operator key to use when signing. Includes validation for the provided key and adjusts the account update logic to respect this selection. Updates tests to verify the new functionality.

Fixes #67