### PR TITLE
Fix deletion logic in SubjectMappings and update test case

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -621,7 +621,7 @@ func (m *SubjectMappingsImpl) Set(subject string, me ...Mapping) error {
 
 func (m *SubjectMappingsImpl) Delete(subject string) error {
 	if m.data.Claim.Mappings != nil {
-		m.data.Claim.Mappings[jwt.Subject(subject)] = nil
+		delete(m.data.Claim.Mappings, jwt.Subject(subject))
 		return m.data.update()
 	}
 	return nil

--- a/tests/accounts_test.go
+++ b/tests/accounts_test.go
@@ -1068,7 +1068,7 @@ func (t *ProviderSuite) Test_SubjectMapping() {
 	t.Nil(sm.Get("bar"))
 
 	t.NoError(sm.Delete("foo"))
-	t.NotContains(mappings, "foo")
+	t.Nil(sm.List())
 }
 
 func (t *ProviderSuite) Test_AccountIssuer() {

--- a/tests/accounts_test.go
+++ b/tests/accounts_test.go
@@ -1068,7 +1068,7 @@ func (t *ProviderSuite) Test_SubjectMapping() {
 	t.Nil(sm.Get("bar"))
 
 	t.NoError(sm.Delete("foo"))
-	t.NoError(sm.Delete("foo"))
+	t.NotContains(mappings, "foo")
 }
 
 func (t *ProviderSuite) Test_AccountIssuer() {


### PR DESCRIPTION
This change replaces mapping deletion with a proper deletion and enhances the relevant test case to ensure the mapping is completely removed.

Fixes #66 