### PR TITLE
Add support for configuring cluster traffic in accounts

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -565,6 +565,19 @@ func (at *AccountTags) All() ([]string, error) {
 	return at.a.Claim.Tags, nil
 }
 
+func (a *AccountData) SetClusterTraffic(traffic string) error {
+	ct := jwt.ClusterTraffic(traffic)
+	if err := ct.Valid(); err != nil {
+		return err
+	}
+	a.Claim.ClusterTraffic = ct
+	return a.update()
+}
+
+func (a *AccountData) ClusterTraffic() string {
+	return string(a.Claim.ClusterTraffic)
+}
+
 func (a *AccountData) SubjectMappings() SubjectMappings {
 	return &SubjectMappingsImpl{a}
 }

--- a/tests/accounts_test.go
+++ b/tests/accounts_test.go
@@ -1109,3 +1109,39 @@ func (t *ProviderSuite) Test_AccountIssuer() {
 	t.NoError(a.SetIssuer(""))
 	t.Equal(a.Issuer(), o.Subject())
 }
+
+func (t *ProviderSuite) Test_ClusterTraffic() {
+	auth, err := authb.NewAuth(t.Provider)
+	t.NoError(err)
+
+	o, err := auth.Operators().Add("O")
+	t.NoError(err)
+	a, err := o.Accounts().Add("A")
+	t.NoError(err)
+	t.Equal("", a.ClusterTraffic())
+	t.NoError(a.SetClusterTraffic("system"))
+	t.Equal("system", a.ClusterTraffic())
+	t.NoError(a.SetClusterTraffic("owner"))
+	t.Equal("owner", a.ClusterTraffic())
+	t.NoError(auth.Commit())
+	t.NoError(auth.Reload())
+
+	o, err = auth.Operators().Get("O")
+	t.NoError(err)
+	a, err = o.Accounts().Get("A")
+	t.NoError(err)
+	t.Equal("owner", a.ClusterTraffic())
+
+	// anything else is an error
+	t.Error(a.SetClusterTraffic("foo"))
+	t.Equal("owner", a.ClusterTraffic())
+	t.NoError(a.SetClusterTraffic(""))
+	t.NoError(auth.Commit())
+	t.NoError(auth.Reload())
+
+	o, err = auth.Operators().Get("O")
+	t.NoError(err)
+	a, err = o.Accounts().Get("A")
+	t.NoError(err)
+	t.Equal("", a.ClusterTraffic())
+}

--- a/types.go
+++ b/types.go
@@ -343,8 +343,17 @@ type Account interface {
 	IssueAuthorizationResponse(claim *jwt.AuthorizationResponseClaims, key string) (string, error)
 	// IssueClaim issues the specified jwt.Claim using the specified account key
 	IssueClaim(claim jwt.Claims, key string) (string, error)
-
+	// SubjectMappings returns the interface for interacting with SubjectMappings
 	SubjectMappings() SubjectMappings
+	// SetClusterTraffic configures the JetStream traffic to go through the system account (default)
+	// or through this account. Possible values to this option are "" (empty string, default), routing
+	// via the system account, "system" route through the system account, "owner" routing through this
+	// account.
+	SetClusterTraffic(traffic string) error
+	// ClusterTraffic returns how JetStream traffic is configured for the account.
+	// An empty string or "system" denotes traffic through the system account (the default).
+	// "owner" denotes traffic through this account.
+	ClusterTraffic() string
 }
 
 type SubjectMappings interface {


### PR DESCRIPTION
Introduce `SetClusterTraffic` and `ClusterTraffic` methods to manage JetStream traffic routing for accounts. Added validation logic for acceptable traffic values and corresponding test cases to ensure correct functionality. Default behavior retains compatibility with prior configurations.