### PR TITLE
Fix operator signing key matching in account issuance logic

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -104,7 +104,7 @@ func (a *AccountData) update() error {
 		return a.issue(a.Operator.Key)
 	}
 	for i := 0; i < len(a.Operator.OperatorSigningKeys); i++ {
-		if a.Claim.Issuer == a.Operator.OperatorSigningKeys[0].Public {
+		if a.Claim.Issuer == a.Operator.OperatorSigningKeys[i].Public {
 			return a.issue(a.Operator.OperatorSigningKeys[i])
 		}
 	}


### PR DESCRIPTION
Corrected the logic to iterate over all operator signing keys when matching the issuer. Added comprehensive tests to ensure account issuance respects the correct signing key, validating issuer behavior and associated operations like tagging, subject mappings, and scoped permissions.

Fix https://github.com/nats-io/natscli/issues/1312#issuecomment-2751349678