### PR TITLE
feat: support response type on service exports

### DIFF
--- a/exports.go
+++ b/exports.go
@@ -229,3 +229,12 @@ func (b *baseExportImpl) GenerateActivationForSubject(account string, issuer str
 	}
 	return b.data.Operator.SigningService.Sign(ac, k)
 }
+
+func (b *ServiceExportImpl) SetResponseType(tf string) error {
+	b.export.ResponseType = jwt.ResponseType(tf)
+	return b.update()
+}
+
+func (b *ServiceExportImpl) ResponseType() string {
+	return string(b.export.ResponseType)
+}

--- a/tests/exports_test.go
+++ b/tests/exports_test.go
@@ -434,3 +434,21 @@ func (t *ProviderSuite) Test_StreamExportAdvertised() {
 	t.NoError(stream.SetAdvertised(true))
 	t.True(stream.IsAdvertised())
 }
+
+func (t *ProviderSuite) Test_ResponseType() {
+	auth, err := authb.NewAuth(t.Provider)
+	t.NoError(err)
+
+	a := t.MaybeCreate(auth, "O", "A")
+	service, err := a.Exports().Services().Add("q", "q.>")
+	t.NoError(err)
+
+	responseType := "Stream"
+	t.NoError(service.SetResponseType(responseType))
+	t.NoError(auth.Commit())
+	t.NoError(auth.Reload())
+
+	service, err = a.Exports().Services().Get("q.>")
+	t.NoError(err)
+	t.Equal(responseType, service.ResponseType())
+}

--- a/types.go
+++ b/types.go
@@ -689,6 +689,10 @@ type ServiceExport interface {
 	AllowTracing() bool
 	// SetAllowTracing enables tracing messages to follow the service implementation
 	SetAllowTracing(tf bool) error
+	// SetResponseType sets the response type for the export
+	SetResponseType(string) error
+	// ResponseType returns the response type for the export
+	ResponseType() string
 }
 
 type StreamExport interface {


### PR DESCRIPTION
We are implementing a solution to create dynamic accounts and manage imports.
We detected that the response type is not available on the current API.