### PR TITLE
Added delete support for accounts on the nsc store.

### DIFF
--- a/providers/kv/kv.go
+++ b/providers/kv/kv.go
@@ -393,8 +393,19 @@ func (p *KvProvider) Store(operators []*ab.OperatorData) error {
 			if err := p.DeleteAccount(a); err != nil {
 				return err
 			}
+			if err := p.DeleteKey(a.Key.Public); err != nil {
+				return err
+			}
+			for _, sk := range a.AccountSigningKeys {
+				if err := p.DeleteKey(sk.Public); err != nil {
+					return err
+				}
+			}
 			for _, u := range a.UserDatas {
 				if err := p.DeleteUser(u); err != nil {
+					return err
+				}
+				if err := p.DeleteKey(u.Key.Public); err != nil {
 					return err
 				}
 			}

--- a/providers/nsc/nsc.go
+++ b/providers/nsc/nsc.go
@@ -1,6 +1,7 @@
 package nsc
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -287,6 +288,56 @@ func (a *NscProvider) Store(operators []*authb.OperatorData) error {
 				}
 			}
 		}
+		for _, account := range o.DeletedAccounts {
+			if !s.Has(store.Accounts, account.EntityName) {
+				continue
+			}
+			// check for users on disk that aren't in the model
+			known := make(map[string]bool)
+			for _, u := range account.UserDatas {
+				known[u.EntityName] = true
+			}
+			diskUsers, err := s.ListEntries(store.Accounts, account.EntityName, store.Users)
+			if err != nil {
+				return err
+			}
+			for _, du := range diskUsers {
+				if !known[du] {
+					return fmt.Errorf("account %s has unknown user %s on disk", account.EntityName, du)
+				}
+			}
+			// delete users
+			for _, u := range account.UserDatas {
+				if err := s.Delete(store.Accounts, account.EntityName, store.Users, store.JwtName(u.EntityName)); err != nil {
+					return err
+				}
+				if err := ks.Remove(u.Key.Public); err != nil {
+					return err
+				}
+			}
+			// remove empty users dir, account jwt, account dir
+			if s.Has(store.Accounts, account.EntityName, store.Users) {
+				if err := s.Delete(store.Accounts, account.EntityName, store.Users); err != nil {
+					return err
+				}
+			}
+			if err := s.Delete(store.Accounts, account.EntityName, store.JwtName(account.EntityName)); err != nil {
+				return err
+			}
+			if err := s.Delete(store.Accounts, account.EntityName); err != nil {
+				return err
+			}
+			if err := ks.Remove(account.Key.Public); err != nil {
+				return err
+			}
+			for _, sk := range account.AccountSigningKeys {
+				if err := ks.Remove(sk.Public); err != nil {
+					return err
+				}
+			}
+		}
+		o.DeletedAccounts = nil
+
 		// update the loaded so that other mods can be detected
 		o.Loaded = o.Claim.IssuedAt
 	}

--- a/tests/accounts_test.go
+++ b/tests/accounts_test.go
@@ -1071,6 +1071,48 @@ func (t *ProviderSuite) Test_SubjectMapping() {
 	t.Nil(sm.List())
 }
 
+func (t *ProviderSuite) Test_DeleteAccountAndDependencies() {
+	auth, err := authb.NewAuth(t.Provider)
+	t.NoError(err)
+
+	o, err := auth.Operators().Add("O")
+	t.NoError(err)
+
+	a, err := o.Accounts().Add("A")
+	t.NoError(err)
+
+	scope, err := a.ScopedSigningKeys().Add()
+	t.NoError(err)
+
+	u, err := a.Users().Add("U", scope)
+	t.NoError(err)
+
+	ak := a.Subject()
+	uk := u.Subject()
+
+	t.NoError(auth.Commit())
+
+	// verify everything exists
+	t.True(t.Store.UserExists("O", "A", "U"))
+	t.True(t.Store.KeyExists(uk))
+	t.True(t.Store.AccountExists("O", "A"))
+	t.True(t.Store.KeyExists(ak))
+	t.True(t.Store.KeyExists(scope))
+
+	// delete the account
+	t.NoError(o.Accounts().Delete("A"))
+	t.NoError(auth.Commit())
+
+	// user and its key should be gone
+	t.False(t.Store.UserExists("O", "A", "U"))
+	t.False(t.Store.KeyExists(uk))
+
+	// account, its key, and signing keys should be gone
+	t.False(t.Store.AccountExists("O", "A"))
+	t.False(t.Store.KeyExists(ak))
+	t.False(t.Store.KeyExists(scope))
+}
+
 func (t *ProviderSuite) Test_AccountIssuer() {
 	auth, err := authb.NewAuth(t.Provider)
 	t.NoError(err)


### PR DESCRIPTION
This possibly needs additional hardening. The NSC store can certainly be manipulated (we are not expecting that to happen, but it certainly can) - Reallly thinking that we need another artifact that we can manage that is used by this lib, even if we can "export" it back to nsc.

Fix #22